### PR TITLE
Update link error in Multile Inheritance in Classes and Interfaces in Java with new available link

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@
     }
     ```
 
-* **Multiple inheritance in Classes and Interfaces in java** [Learn from here](http://codeinventions.blogspot.in/2014/07/can-interface-extend-multiple.html)
+* **Multiple inheritance in Classes and Interfaces in java** [Learn from here](https://www.geeksforgeeks.org/java-and-multiple-inheritance/)
 
 * **What are the design patterns?** [Learn from here](https://blog.mindorks.com/mastering-design-patterns-in-android-with-kotlin)
     - Creational patterns


### PR DESCRIPTION
The link in the **Multiple inheritance in Classes and Interfaces in java** part is not available. So I replace with the new one from Geekforgeeks, which is a trusted source.

![image](https://user-images.githubusercontent.com/43868345/104023923-ede4d880-51f4-11eb-88e0-02c515adadb5.png)
